### PR TITLE
Erc1155 support

### DIFF
--- a/source/light/contracts/Light.sol
+++ b/source/light/contracts/Light.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./interfaces/ILight.sol";
 
 /**
@@ -13,7 +14,7 @@ import "./interfaces/ILight.sol";
  * Ported from Airswap to add support for sending ERC1155 tokens and removing fee logic.
  * @notice https://www.airswap.io/
  */
-contract Light is ILight {
+contract Light is ILight, ReentrancyGuard {
   using SafeERC20 for IERC20;
   using SafeMath for uint256;
 
@@ -60,7 +61,6 @@ contract Light is ILight {
 
   mapping(address => address) public override authorized;
 
-
   constructor() {
     uint256 currentChainId = getChainId();
     DOMAIN_CHAIN_ID = currentChainId;
@@ -96,7 +96,7 @@ contract Light is ILight {
     uint256 signerAmount,
     address senderToken,
     uint256 senderTokenId,
-    uint256 senderAmount,    
+    uint256 senderAmount,
     uint8 v,
     bytes32 r,
     bytes32 s
@@ -180,7 +180,7 @@ contract Light is ILight {
     uint8 v,
     bytes32 r,
     bytes32 s
-  ) public override {
+  ) public override nonReentrant {
     require(DOMAIN_CHAIN_ID == getChainId(), "CHAIN_ID_CHANGED");
 
     // Ensure the expiry is not passed

--- a/source/light/contracts/Light.sol
+++ b/source/light/contracts/Light.sol
@@ -3,16 +3,17 @@
 /* solhint-disable var-name-mixedcase */
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "./interfaces/ILight.sol";
 
 /**
  * @title AirSwap Light: Atomic Swap between Tokens
+ * Ported from Airswap to add support for sending ERC1155 tokens and removing fee logic.
  * @notice https://www.airswap.io/
  */
-contract Light is ILight, Ownable {
+contract Light is ILight {
   using SafeERC20 for IERC20;
   using SafeMath for uint256;
 
@@ -37,24 +38,21 @@ contract Light is ILight, Ownable {
         "address signerWallet,",
         "address signerToken,",
         "uint256 signerAmount,",
-        "uint256 signerFee,",
         "address senderWallet,",
         "address senderToken,",
+        "uint256 senderTokenId,",
         "uint256 senderAmount",
         ")"
       )
     );
 
-  bytes32 public constant DOMAIN_NAME = keccak256("SWAP_LIGHT");
-  bytes32 public constant DOMAIN_VERSION = keccak256("3");
+  bytes32 public constant DOMAIN_NAME = keccak256("SWAP_LIGHT_1155");
+  bytes32 public constant DOMAIN_VERSION = keccak256("1");
   uint256 public immutable DOMAIN_CHAIN_ID;
   bytes32 public immutable DOMAIN_SEPARATOR;
 
-  uint256 public constant FEE_DIVISOR = 10000;
-  uint256 public signerFee;
-
   /**
-   * @notice Double mapping of signers to nonce groups to nonce states
+   * @dev Double mapping of signers to nonce groups to nonce states
    * @dev The nonce group is computed as nonce / 256, so each group of 256 sequential nonces uses the same key
    * @dev The nonce states are encoded as 256 bits, for each nonce in the group 0 means available and 1 means used
    */
@@ -62,13 +60,8 @@ contract Light is ILight, Ownable {
 
   mapping(address => address) public override authorized;
 
-  address public feeWallet;
 
-  constructor(address _feeWallet, uint256 _fee) {
-    // Ensure the fee wallet is not null
-    require(_feeWallet != address(0), "INVALID_FEE_WALLET");
-    // Ensure the fee is less than divisor
-    require(_fee < FEE_DIVISOR, "INVALID_FEE");
+  constructor() {
     uint256 currentChainId = getChainId();
     DOMAIN_CHAIN_ID = currentChainId;
     DOMAIN_SEPARATOR = keccak256(
@@ -80,19 +73,16 @@ contract Light is ILight, Ownable {
         this
       )
     );
-
-    feeWallet = _feeWallet;
-    signerFee = _fee;
   }
 
   /**
-   * @notice Atomic ERC20 Swap
+   * @notice Atomic ERC20/IERC1155 Swap
    * @param nonce uint256 Unique and should be sequential
    * @param expiry uint256 Expiry in seconds since 1 January 1970
    * @param signerWallet address Wallet of the signer
    * @param signerToken address ERC20 token transferred from the signer
    * @param signerAmount uint256 Amount transferred from the signer
-   * @param senderToken address ERC20 token transferred from the sender
+   * @param senderToken address ERC1155 token transferred from the sender
    * @param senderAmount uint256 Amount transferred from the sender
    * @param v uint8 "v" value of the ECDSA signature
    * @param r bytes32 "r" value of the ECDSA signature
@@ -105,7 +95,8 @@ contract Light is ILight, Ownable {
     address signerToken,
     uint256 signerAmount,
     address senderToken,
-    uint256 senderAmount,
+    uint256 senderTokenId,
+    uint256 senderAmount,    
     uint8 v,
     bytes32 r,
     bytes32 s
@@ -118,33 +109,12 @@ contract Light is ILight, Ownable {
       signerToken,
       signerAmount,
       senderToken,
+      senderTokenId,
       senderAmount,
       v,
       r,
       s
     );
-  }
-
-  /**
-   * @notice Set the fee wallet
-   * @param newFeeWallet address Wallet to transfer signerFee to
-   */
-  function setFeeWallet(address newFeeWallet) external onlyOwner {
-    // Ensure the new fee wallet is not null
-    require(newFeeWallet != address(0), "INVALID_FEE_WALLET");
-    feeWallet = newFeeWallet;
-    emit SetFeeWallet(newFeeWallet);
-  }
-
-  /**
-   * @notice Set the fee
-   * @param newSignerFee uint256 Value of the fee in basis points
-   */
-  function setFee(uint256 newSignerFee) external onlyOwner {
-    // Ensure the fee is less than divisor
-    require(newSignerFee < FEE_DIVISOR, "INVALID_FEE");
-    signerFee = newSignerFee;
-    emit SetFee(newSignerFee);
   }
 
   /**
@@ -184,14 +154,14 @@ contract Light is ILight, Ownable {
   }
 
   /**
-   * @notice Atomic ERC20 Swap with Recipient
+   * @notice Atomic ERC20/IERC1155 Swap with Recipient
    * @param recipient Wallet of the recipient
    * @param nonce uint256 Unique and should be sequential
    * @param expiry uint256 Expiry in seconds since 1 January 1970
    * @param signerWallet address Wallet of the signer
    * @param signerToken address ERC20 token transferred from the signer
    * @param signerAmount uint256 Amount transferred from the signer
-   * @param senderToken address ERC20 token transferred from the sender
+   * @param senderToken address IERC1155 token transferred from the sender
    * @param senderAmount uint256 Amount transferred from the sender
    * @param v uint8 "v" value of the ECDSA signature
    * @param r bytes32 "r" value of the ECDSA signature
@@ -205,6 +175,7 @@ contract Light is ILight, Ownable {
     address signerToken,
     uint256 signerAmount,
     address senderToken,
+    uint256 senderTokenId,
     uint256 senderAmount,
     uint8 v,
     bytes32 r,
@@ -223,6 +194,7 @@ contract Light is ILight, Ownable {
       signerAmount,
       msg.sender,
       senderToken,
+      senderTokenId,
       senderAmount
     );
 
@@ -238,20 +210,16 @@ contract Light is ILight, Ownable {
     }
 
     // Transfer token from sender to signer
-    IERC20(senderToken).safeTransferFrom(
+    IERC1155(senderToken).safeTransferFrom(
       msg.sender,
       signerWallet,
-      senderAmount
+      senderTokenId,
+      senderAmount,
+      bytes("")
     );
 
     // Transfer token from signer to recipient
     IERC20(signerToken).safeTransferFrom(signerWallet, recipient, signerAmount);
-
-    // Transfer fee from signer to feeWallet
-    uint256 feeAmount = signerAmount.mul(signerFee).div(FEE_DIVISOR);
-    if (feeAmount > 0) {
-      IERC20(signerToken).safeTransferFrom(signerWallet, feeWallet, feeAmount);
-    }
 
     // Emit a Swap event
     emit Swap(
@@ -260,9 +228,9 @@ contract Light is ILight, Ownable {
       signerWallet,
       signerToken,
       signerAmount,
-      signerFee,
       msg.sender,
       senderToken,
+      senderTokenId,
       senderAmount
     );
   }
@@ -319,44 +287,6 @@ contract Light is ILight, Ownable {
   }
 
   /**
-   * @notice Hash order parameters
-   * @param nonce uint256
-   * @param expiry uint256
-   * @param signerWallet address
-   * @param signerToken address
-   * @param signerAmount uint256
-   * @param senderToken address
-   * @param senderAmount uint256
-   * @return bytes32
-   */
-  function _getOrderHash(
-    uint256 nonce,
-    uint256 expiry,
-    address signerWallet,
-    address signerToken,
-    uint256 signerAmount,
-    address senderWallet,
-    address senderToken,
-    uint256 senderAmount
-  ) internal view returns (bytes32) {
-    return
-      keccak256(
-        abi.encode(
-          LIGHT_ORDER_TYPEHASH,
-          nonce,
-          expiry,
-          signerWallet,
-          signerToken,
-          signerAmount,
-          signerFee,
-          senderWallet,
-          senderToken,
-          senderAmount
-        )
-      );
-  }
-
-  /**
    * @notice Recover the signatory from a signature
    * @param hash bytes32
    * @param v uint8
@@ -376,5 +306,44 @@ contract Light is ILight, Ownable {
     // Ensure the signatory is not null
     require(signatory != address(0), "INVALID_SIG");
     return signatory;
+  }
+
+  /**
+   * @notice Hash order parameters
+   * @param nonce uint256
+   * @param expiry uint256
+   * @param signerWallet address
+   * @param signerToken address
+   * @param signerAmount uint256
+   * @param senderToken address
+   * @param senderAmount uint256
+   * @return bytes32
+   */
+  function _getOrderHash(
+    uint256 nonce,
+    uint256 expiry,
+    address signerWallet,
+    address signerToken,
+    uint256 signerAmount,
+    address senderWallet,
+    address senderToken,
+    uint256 senderTokenId,
+    uint256 senderAmount
+  ) internal pure returns (bytes32) {
+    return
+      keccak256(
+        abi.encode(
+          LIGHT_ORDER_TYPEHASH,
+          nonce,
+          expiry,
+          signerWallet,
+          signerToken,
+          signerAmount,
+          senderWallet,
+          senderToken,
+          senderTokenId,
+          senderAmount
+        )
+      );
   }
 }

--- a/source/light/contracts/interfaces/ILight.sol
+++ b/source/light/contracts/interfaces/ILight.sol
@@ -9,9 +9,9 @@ interface ILight {
     address indexed signerWallet,
     address signerToken,
     uint256 signerAmount,
-    uint256 signerFee,
     address indexed senderWallet,
     address senderToken,
+    uint256 senderTokenId,
     uint256 senderAmount
   );
 
@@ -21,10 +21,6 @@ interface ILight {
 
   event Revoke(address indexed signer, address indexed signerWallet);
 
-  event SetFee(uint256 indexed signerFee);
-
-  event SetFeeWallet(address indexed feeWallet);
-
   function swap(
     uint256 nonce,
     uint256 expiry,
@@ -32,6 +28,7 @@ interface ILight {
     address signerToken,
     uint256 signerAmount,
     address senderToken,
+    uint256 senderTokenId,
     uint256 senderAmount,
     uint8 v,
     bytes32 r,
@@ -46,6 +43,7 @@ interface ILight {
     address signerToken,
     uint256 signerAmount,
     address senderToken,
+    uint256 senderTokenId,
     uint256 senderAmount,
     uint8 v,
     bytes32 r,

--- a/source/light/package.json
+++ b/source/light/package.json
@@ -7,6 +7,7 @@
     "Don Mosites",
     "Ethan Wessel"
   ],
+  "main": "deploy.js",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/source/light/test/unit.js
+++ b/source/light/test/unit.js
@@ -8,6 +8,7 @@ const {
 const { ethers, waffle } = require('hardhat')
 const { deployMockContract } = waffle
 const IERC20 = require('@openzeppelin/contracts/build/contracts/IERC20.json')
+const IERC1155 = require('@openzeppelin/contracts/build/contracts/IERC1155.json')
 
 describe('Light Unit Tests', () => {
   let snapshotId
@@ -18,34 +19,32 @@ describe('Light Unit Tests', () => {
   let deployer
   let sender
   let signer
-  let feeWallet
   let anyone
 
   const CHAIN_ID = 31337
-  const SIGNER_FEE = '30'
-  const HIGHER_FEE = '50'
-  const FEE_DIVISOR = '10000'
   const DEFAULT_AMOUNT = '10000'
+  const DEFAULT_TOKEN_ID = '1'
 
   async function createSignedOrder(params, signer) {
     const unsignedOrder = createLightOrder({
-      signerFee: SIGNER_FEE,
       signerWallet: signer.address,
       signerToken: signerToken.address,
       signerAmount: DEFAULT_AMOUNT,
       senderWallet: sender.address,
       senderToken: senderToken.address,
+      senderTokenId: DEFAULT_TOKEN_ID,
       senderAmount: DEFAULT_AMOUNT,
       ...params,
     })
+    const sig = await createLightSignature(
+      unsignedOrder,
+      signer,
+      light.address,
+      CHAIN_ID
+    )
     return lightOrderToParams({
       ...unsignedOrder,
-      ...(await createLightSignature(
-        unsignedOrder,
-        signer,
-        light.address,
-        CHAIN_ID
-      )),
+      ...sig,
     })
   }
 
@@ -58,42 +57,15 @@ describe('Light Unit Tests', () => {
   })
 
   before('get signers and deploy', async () => {
-    ;[deployer, sender, signer, feeWallet, anyone] = await ethers.getSigners()
+    ;[deployer, sender, signer, anyone] = await ethers.getSigners()
 
     signerToken = await deployMockContract(deployer, IERC20.abi)
-    senderToken = await deployMockContract(deployer, IERC20.abi)
+    senderToken = await deployMockContract(deployer, IERC1155.abi)
     await signerToken.mock.transferFrom.returns(true)
-    await senderToken.mock.transferFrom.returns(true)
+    await senderToken.mock.safeTransferFrom.returns()
 
-    light = await (
-      await ethers.getContractFactory('Light')
-    ).deploy(feeWallet.address, SIGNER_FEE)
+    light = await (await ethers.getContractFactory('Light')).deploy()
     await light.deployed()
-  })
-
-  describe('Constructor', async () => {
-    it('constructor sets default values', async () => {
-      const storedFee = await light.signerFee()
-      const storedFeeWallet = await light.feeWallet()
-      await expect(storedFee).to.equal(SIGNER_FEE)
-      await expect(storedFeeWallet).to.equal(feeWallet.address)
-    })
-
-    it('test invalid feeWallet', async () => {
-      await expect(
-        (
-          await ethers.getContractFactory('Light')
-        ).deploy(ADDRESS_ZERO, SIGNER_FEE)
-      ).to.be.revertedWith('INVALID_FEE_WALLET')
-    })
-
-    it('test invalid fee', async () => {
-      await expect(
-        (
-          await ethers.getContractFactory('Light')
-        ).deploy(feeWallet.address, 100000000000)
-      ).to.be.revertedWith('INVALID_FEE')
-    })
   })
 
   describe('Test swap', async () => {
@@ -176,75 +148,9 @@ describe('Light Unit Tests', () => {
 
     it('test invalid signature', async () => {
       const order = await createSignedOrder({}, signer)
-      order[7] = '29' // Change "v" of signature
+      order[8] = '29' // Change "v" of signature to make invalid - index 8 is v
       await expect(light.connect(sender).swap(...order)).to.be.revertedWith(
         'INVALID_SIG'
-      )
-    })
-  })
-
-  describe('Test fees', async () => {
-    it('test changing fee wallet', async () => {
-      await light.connect(deployer).setFeeWallet(anyone.address)
-
-      const storedFeeWallet = await light.feeWallet()
-      await expect(await storedFeeWallet).to.equal(anyone.address)
-    })
-
-    it('test only deployer can change fee wallet', async () => {
-      await expect(
-        light.connect(anyone).setFeeWallet(anyone.address)
-      ).to.be.revertedWith('Ownable: caller is not the owner')
-    })
-
-    it('test invalid fee wallet', async () => {
-      await expect(
-        light.connect(deployer).setFeeWallet(ADDRESS_ZERO)
-      ).to.be.revertedWith('INVALID_FEE_WALLET')
-    })
-
-    it('test changing fee', async () => {
-      await light.connect(deployer).setFee(HIGHER_FEE)
-
-      const storedSignerFee = await light.signerFee()
-      await expect(await storedSignerFee).to.equal(HIGHER_FEE)
-    })
-
-    it('test only deployer can change fee', async () => {
-      await expect(light.connect(anyone).setFee('0')).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-    })
-
-    it('test zero fee', async () => {
-      const order = await createSignedOrder(
-        {
-          signerFee: '0',
-        },
-        signer
-      )
-      await light.connect(deployer).setFee('0')
-      await expect(await light.connect(sender).swap(...order)).to.emit(
-        light,
-        'Swap'
-      )
-    })
-
-    it('test invalid fee', async () => {
-      await expect(
-        light.connect(deployer).setFee(FEE_DIVISOR + 1)
-      ).to.be.revertedWith('INVALID_FEE')
-    })
-
-    it('test when signed with incorrect fee', async () => {
-      const order = await createSignedOrder(
-        {
-          signerFee: HIGHER_FEE / 2,
-        },
-        signer
-      )
-      await expect(light.connect(sender).swap(...order)).to.be.revertedWith(
-        'UNAUTHORIZED'
       )
     })
   })

--- a/source/validator/contracts/Validator.sol
+++ b/source/validator/contracts/Validator.sol
@@ -22,6 +22,7 @@ contract Validator is Ownable {
     uint256 senderAmount;
     IERC20 signerToken;
     IERC20 senderToken;
+    uint256 senderTokenId;
     uint8 v;
     bytes32 r;
     bytes32 s;
@@ -38,9 +39,9 @@ contract Validator is Ownable {
         "address signerWallet,",
         "address signerToken,",
         "uint256 signerAmount,",
-        "uint256 signerFee,",
         "address senderWallet,",
         "address senderToken,",
+        "uint256 senderTokenId,",
         "uint256 senderAmount",
         ")"
       )
@@ -105,9 +106,8 @@ contract Validator is Ownable {
     details.senderWallet = senderWallet;
     bytes32 hashed = _getOrderHash(details);
     address signatory = _getSignatory(hashed, v, r, s);
-    uint256 swapFee = details.signerAmount.mul(Light(light).signerFee()).div(
-      Light(light).FEE_DIVISOR()
-    );
+    uint256 swapFee = 0;
+
     // Ensure the signatory is not null
     if (signatory == address(0)) {
       errors[errCount] = "INVALID_SIG";
@@ -184,7 +184,7 @@ contract Validator is Ownable {
           _details.signerWallet,
           _details.signerToken,
           _details.signerAmount,
-          Light(light).signerFee(),
+          0,
           _details.senderWallet,
           _details.senderToken,
           _details.senderAmount

--- a/source/wrapper/contracts/Wrapper.sol
+++ b/source/wrapper/contracts/Wrapper.sol
@@ -74,6 +74,7 @@ contract Wrapper {
       signerToken,
       signerAmount,
       senderToken,
+      0, // fake placeholder
       senderAmount,
       v,
       r,

--- a/tools/constants/index.ts
+++ b/tools/constants/index.ts
@@ -1,7 +1,7 @@
 export const DOMAIN_NAME = 'SWAP'
 export const DOMAIN_VERSION = '2'
-export const LIGHT_DOMAIN_NAME = 'SWAP_LIGHT'
-export const LIGHT_DOMAIN_VERSION = '3'
+export const LIGHT_DOMAIN_NAME = 'SWAP_LIGHT_1155'
+export const LIGHT_DOMAIN_VERSION = '1'
 export const INDEX_HEAD = '0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF'
 export const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
 export const LOCATOR_ZERO =

--- a/tools/types/index.ts
+++ b/tools/types/index.ts
@@ -57,9 +57,9 @@ export type UnsignedLightOrder = {
   signerWallet: string
   signerToken: string
   signerAmount: string
-  signerFee: string
   senderWallet: string
   senderToken: string
+  senderTokenId: string
   senderAmount: string
 }
 
@@ -70,6 +70,7 @@ export type LightOrder = {
   signerToken: string
   signerAmount: string
   senderToken: string
+  senderTokenId: string
   senderAmount: string
 } & LightSignature
 
@@ -120,9 +121,9 @@ export const EIP712Light = {
     { name: 'signerWallet', type: 'address' },
     { name: 'signerToken', type: 'address' },
     { name: 'signerAmount', type: 'uint256' },
-    { name: 'signerFee', type: 'uint256' },
     { name: 'senderWallet', type: 'address' },
     { name: 'senderToken', type: 'address' },
+    { name: 'senderTokenId', type: 'uint256' },
     { name: 'senderAmount', type: 'uint256' },
   ],
 }

--- a/tools/utils/src/orders.ts
+++ b/tools/utils/src/orders.ts
@@ -42,9 +42,9 @@ export function createLightOrder({
   signerWallet = ADDRESS_ZERO,
   signerToken = ADDRESS_ZERO,
   signerAmount = '0',
-  signerFee = '0',
   senderWallet = ADDRESS_ZERO,
   senderToken = ADDRESS_ZERO,
+  senderTokenId = '1',
   senderAmount = '0',
 }: any): UnsignedLightOrder {
   return {
@@ -53,9 +53,9 @@ export function createLightOrder({
     signerWallet,
     signerToken,
     signerAmount: String(signerAmount),
-    signerFee: String(signerFee),
     senderWallet,
     senderToken,
+    senderTokenId: String(senderTokenId),
     senderAmount: String(senderAmount),
   }
 }
@@ -132,6 +132,7 @@ export function lightOrderToParams(order: LightOrder): Array<string> {
     order.signerToken,
     order.signerAmount,
     order.senderToken,
+    order.senderTokenId,
     order.senderAmount,
     order.v,
     order.r,


### PR DESCRIPTION
This change adds the capability for an ERC1155 to be swapped with an ERC20 using the Light Swap contract. The `Light.sol` file is the main solidity change.

The logic is set to support the following use case:

A `signer` creates an order specifying they would like to use an ERC20 token to purchase an ERC1155 token, specifying the amounts and other params, and signs the order.  They approve the Light.sol contract to move the ERC20 tokens.

A `sender` fills the order by approving the Light.sol contract to move the ERC1155 tokens, taking the order details and the signers signature and submits it to the contract. The contract will verify the details and use transferFrom to swap the tokens between the addresses.

Note that ERC20 is only supported on the signer side and ERC1155 is only supported on the sender side.

* All fee logic was removed to keep stack to large errors from happening when adding a new tokenId param to the function signatures. Otherwise this will require a larger, more risky refactor.
* No other submodules in the repo were updated to support the ERC1155 logic, so it may require more work if we want to use other modules in the future.
* Unit tests were updated to mock the ERC1155 sender token, but should be tested on testnet before usage to ensure it works as expected.